### PR TITLE
Fix issue #36

### DIFF
--- a/src/main/java/ml/pkom/itemalchemy/gui/screen/AlchemyTableScreenHandler.java
+++ b/src/main/java/ml/pkom/itemalchemy/gui/screen/AlchemyTableScreenHandler.java
@@ -293,7 +293,7 @@ public class AlchemyTableScreenHandler extends SimpleScreenHandler {
 
             int receivable = 1;
             if (actionType == SlotActionType.QUICK_MOVE) {
-                receivable = (int) Math.min(Math.floorDiv(EMCManager.getEmcFromPlayer(player), EMCManager.get(definedStack)), 64);
+                receivable = (int) Math.min(Math.floorDiv(EMCManager.getEmcFromPlayer(player), EMCManager.get(definedStack)), definedStack.getMaxCount());
             }
 
 


### PR DESCRIPTION
Fixes #36 by using the max count of the stack instead of a magic value of 64 when determining how many items the player can take out.

Testing needed for if the amount of EMC removed is correct when taking out items with a higher/lower max count than 64.