### PR TITLE
Fix alchemy table search issue #39

### DIFF
--- a/src/main/java/ml/pkom/itemalchemy/gui/inventory/ExtractInventory.java
+++ b/src/main/java/ml/pkom/itemalchemy/gui/inventory/ExtractInventory.java
@@ -57,19 +57,17 @@ public class ExtractInventory extends SimpleInventory {
 
         List<String> keys = new ArrayList<>(items.getKeys());
 
-        if (!keys.isEmpty()) {
-            for (int i = 0 ; i < 13; i++) {
-                int id_index = i + (index * 13);
-                if (keys.size() < id_index + 1) {
-                    setStack(i + 64, ItemStack.EMPTY);
-                    continue;
-                }
-                Identifier id = new Identifier(keys.get(id_index));
-                //System.out.println(id);
-                if (!ItemUtil.isExist(id)) continue;
-                ItemStack itemStack = new ItemStack(ItemUtil.fromId(id), 1);
-                setStack(i + 64, itemStack);
+        for (int i = 0; i < 13; i++) {
+            int id_index = i + (index * 13);
+            if (keys.size() < id_index + 1) {
+                setStack(i + 64, ItemStack.EMPTY);
+                continue;
             }
+            Identifier id = new Identifier(keys.get(id_index));
+            //System.out.println(id);
+            if (!ItemUtil.isExist(id)) continue;
+            ItemStack itemStack = new ItemStack(ItemUtil.fromId(id), 1);
+            setStack(i + 64, itemStack);
         }
         isSettingStack = false;
     }

--- a/src/main/java/ml/pkom/itemalchemy/gui/screen/AlchemyTableScreenHandler.java
+++ b/src/main/java/ml/pkom/itemalchemy/gui/screen/AlchemyTableScreenHandler.java
@@ -274,6 +274,11 @@ public class AlchemyTableScreenHandler extends SimpleScreenHandler {
                     translatedName = I18n.translate(itemTranslationKey);
                 }
 
+                // Make sure everything is lower-case so capitalization doesn't matter for searching
+                searchText = searchText.toLowerCase();
+                translatedName = translatedName.toLowerCase();
+                id = id.toLowerCase();
+
                 // Display the item if the items id, translated name or custom name contains
                 // the search term. Checking both the id and the translated name
                 // makes sure that people can search in both their native language

--- a/src/main/java/ml/pkom/itemalchemy/gui/screen/AlchemyTableScreenHandler.java
+++ b/src/main/java/ml/pkom/itemalchemy/gui/screen/AlchemyTableScreenHandler.java
@@ -266,13 +266,17 @@ public class AlchemyTableScreenHandler extends SimpleScreenHandler {
             for (String id : ids) {
                 String translatedName = "";
 
-                ItemStack itemStack = new ItemStack(ItemUtil.fromId(new Identifier(id)));
+                Identifier itemIdentifier = new Identifier(id);
+                ItemStack itemStack = new ItemStack(ItemUtil.fromId(itemIdentifier));
                 String itemTranslationKey = itemStack.getTranslationKey();
 
                 // If the item has a translation, we should use that instead of the identifier.
                 if (I18n.hasTranslation(itemTranslationKey)) {
                     translatedName = I18n.translate(itemTranslationKey);
                 }
+
+                // Include only the name of the item in the id when searching
+                String itemId = itemIdentifier.getPath();
 
                 // Make sure everything is lower-case so capitalization doesn't matter for searching
                 searchText = searchText.toLowerCase();
@@ -283,7 +287,7 @@ public class AlchemyTableScreenHandler extends SimpleScreenHandler {
                 // the search term. Checking both the id and the translated name
                 // makes sure that people can search in both their native language
                 // and in English.
-                if (id.contains(searchText) || translatedName.contains(searchText) || itemStack.getName().asString().contains(searchText)) continue;
+                if (itemId.contains(searchText) || translatedName.contains(searchText) || itemStack.getName().asString().contains(searchText)) continue;
 
                 items.remove(id);
             }

--- a/src/main/java/ml/pkom/itemalchemy/gui/screen/AlchemyTableScreenHandler.java
+++ b/src/main/java/ml/pkom/itemalchemy/gui/screen/AlchemyTableScreenHandler.java
@@ -24,6 +24,8 @@ import net.minecraft.util.Identifier;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class AlchemyTableScreenHandler extends SimpleScreenHandler {
     public RegisterInventory registerInventory; // contains InputSlot(0)
@@ -240,7 +242,7 @@ public class AlchemyTableScreenHandler extends SimpleScreenHandler {
         return ItemStack.EMPTY;
     }
 
-    public String searchText = "";
+    public String searchText, searchNamespace = "";
 
     public void setSearchText(String searchText) {
         this.searchText = searchText;
@@ -263,6 +265,15 @@ public class AlchemyTableScreenHandler extends SimpleScreenHandler {
             }
 
             List<String> ids = new ArrayList<>(items.getKeys());
+
+            // Extract namespace from searchText [@(NAMESPACE)]
+            Pattern pattern = Pattern.compile("@([a-zA-Z0-9_-]+)");
+            Matcher matcher = pattern.matcher(searchText);
+            if (matcher.find()) {
+                searchNamespace = matcher.group(1);
+                searchText = searchText.replaceFirst("@" + searchNamespace + " ?", "");
+            }
+
             for (String id : ids) {
                 String translatedName = "";
 
@@ -283,11 +294,18 @@ public class AlchemyTableScreenHandler extends SimpleScreenHandler {
                 translatedName = translatedName.toLowerCase();
                 id = id.toLowerCase();
 
+                String itemNamespace = itemIdentifier.getNamespace();
+
                 // Display the item if the items id, translated name or custom name contains
                 // the search term. Checking both the id and the translated name
                 // makes sure that people can search in both their native language
                 // and in English.
-                if (itemId.contains(searchText) || translatedName.contains(searchText) || itemStack.getName().asString().contains(searchText)) continue;
+                if (
+                        (searchNamespace.isEmpty() || itemNamespace.contains(searchNamespace)) &&
+                        (itemId.contains(searchText) ||
+                        translatedName.contains(searchText) ||
+                        itemStack.getName().asString().contains(searchText))
+                ) continue;
 
                 items.remove(id);
             }

--- a/src/main/java/ml/pkom/itemalchemy/gui/screen/AlchemyTableScreenHandler.java
+++ b/src/main/java/ml/pkom/itemalchemy/gui/screen/AlchemyTableScreenHandler.java
@@ -10,6 +10,7 @@ import ml.pkom.mcpitanlibarch.api.entity.Player;
 import ml.pkom.mcpitanlibarch.api.gui.SimpleScreenHandler;
 import ml.pkom.mcpitanlibarch.api.util.ItemUtil;
 import ml.pkom.mcpitanlibarch.api.util.SlotUtil;
+import net.minecraft.client.resource.language.I18n;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.inventory.SimpleInventory;
@@ -263,9 +264,23 @@ public class AlchemyTableScreenHandler extends SimpleScreenHandler {
 
             List<String> ids = new ArrayList<>(items.getKeys());
             for (String id : ids) {
-                if (!id.contains(searchText) && !new ItemStack(ItemUtil.fromId(new Identifier(id))).getName().getString().contains(searchText)) {
-                    items.remove(id);
+                String translatedName = "";
+
+                ItemStack itemStack = new ItemStack(ItemUtil.fromId(new Identifier(id)));
+                String itemTranslationKey = itemStack.getTranslationKey();
+
+                // If the item has a translation, we should use that instead of the identifier.
+                if (I18n.hasTranslation(itemTranslationKey)) {
+                    translatedName = I18n.translate(itemTranslationKey);
                 }
+
+                // Display the item if the items id, translated name or custom name contains
+                // the search term. Checking both the id and the translated name
+                // makes sure that people can search in both their native language
+                // and in English.
+                if (id.contains(searchText) || translatedName.contains(searchText) || itemStack.getName().asString().contains(searchText)) continue;
+
+                items.remove(id);
             }
 
             itemAlchemyTag.put("registered_items", items);


### PR DESCRIPTION
Fixes #39 by using the translation of the item name when possible in addition to the id of the item. 

Allows people to search for items in their native language.
Makes the alchemy table show no items when no items match the search query.


Please review changes