### PR TITLE
Fix durability bar not changing with charge in 1.21

### DIFF
--- a/src/main/java/net/pitan76/itemalchemy/item/AlchemicalToolMaterials.java
+++ b/src/main/java/net/pitan76/itemalchemy/item/AlchemicalToolMaterials.java
@@ -5,8 +5,8 @@ import net.pitan76.mcpitanlib.api.item.tool.CompatibleToolMaterial;
 
 public enum AlchemicalToolMaterials implements CompatibleToolMaterial {
 
-    DARK_MATTER(3, 0, 10.0F, 2.0F, 16, Ingredient.ofItems(Items.DARK_MATTER.getOrNull())),
-    RED_MATTER(3, 0, 15.0F, 4.0F, 20, Ingredient.ofItems(Items.RED_MATTER.getOrNull()));
+    DARK_MATTER(3, 16, 10.0F, 2.0F, 16, Ingredient.ofItems(Items.DARK_MATTER.getOrNull())),
+    RED_MATTER(3, 16, 15.0F, 4.0F, 20, Ingredient.ofItems(Items.RED_MATTER.getOrNull()));
 
     private final int miningLevel;
     private final int itemDurability;


### PR DESCRIPTION
#104 I did a quick test in 1.18.2 to ensure the charge bar changing works. I also verified the change fixes the bar not changing in 1.21 as well.

Tools still not changing behavior with charge, still taking a look into that.