### PR TITLE
fix: stop the EMC Collector target slot from eating items

### DIFF
--- a/src/main/java/net/pitan76/itemalchemy/gui/screen/EMCCollectorScreenHandler.java
+++ b/src/main/java/net/pitan76/itemalchemy/gui/screen/EMCCollectorScreenHandler.java
@@ -1,6 +1,7 @@
 package net.pitan76.itemalchemy.gui.screen;
 
 import net.minecraft.screen.slot.Slot;
+import net.pitan76.itemalchemy.EMCManager;
 import net.pitan76.itemalchemy.gui.slot.TargetSlot;
 import net.pitan76.itemalchemy.tile.EMCCollectorTile;
 import net.pitan76.mcpitanlib.api.entity.Player;
@@ -71,7 +72,13 @@ public class EMCCollectorScreenHandler extends ExtendedScreenHandler {
 
             if (index < 36) {
                 if (!this.callInsertItem(originalStack.toMinecraft(), 36 + 3, 36 + 16 + 3, false)) {
-                    if (!this.callInsertItem(originalStack.toMinecraft(), 36, 36 + 3, false)) {
+                    // Skip 37, the target slot. Its canInsert keeps the empty slot pass of
+                    // insertItem out, but the pass that merges into an already occupied slot
+                    // does not consult canInsert at all -- it writes the count straight onto
+                    // the stack in the slot, which would move a whole stack into a slot that
+                    // is only ever meant to display one item.
+                    if (!this.callInsertItem(originalStack.toMinecraft(), 36, 37, false)
+                            && !this.callInsertItem(originalStack.toMinecraft(), 38, 36 + 3, false)) {
                         return ItemStackUtil.empty();
                     }
                 }
@@ -100,11 +107,22 @@ public class EMCCollectorScreenHandler extends ExtendedScreenHandler {
     @Override
     public void onSlotClick(SlotClickEvent e) {
         if (e.slot == 37) { // Target Slot
-            ItemStack oldStack = getCursorStackM().copy();
-            super.onSlotClick(e);
-            if (!oldStack.isEmpty()) {
-                setCursorStack(oldStack);
+            // Set what is displayed directly, the same way EMCCondenserScreenHandler does.
+            // Letting vanilla move the stack in and putting the cursor back afterwards loses
+            // items whenever that restore does not run, e.g. when the drag handler goes
+            // through doClick and never reaches this method.
+            Slot targetSlot = ScreenHandlerUtil.getSlot(this, 37);
+            ItemStack cursorStack = getCursorStackM();
+
+            if (cursorStack.isEmpty()) {
+                SlotUtil.setStack(targetSlot, ItemStackUtil.empty());
+                return;
             }
+
+            ItemStack newStack = cursorStack.getItem().createStack();
+            if (EMCManager.get(newStack.getItem()) == 0) return;
+
+            SlotUtil.setStack(targetSlot, newStack.toMinecraft());
             return;
         }
         super.onSlotClick(e);

--- a/src/main/java/net/pitan76/itemalchemy/gui/slot/TargetSlot.java
+++ b/src/main/java/net/pitan76/itemalchemy/gui/slot/TargetSlot.java
@@ -2,7 +2,6 @@ package net.pitan76.itemalchemy.gui.slot;
 
 import net.minecraft.screen.ScreenHandler;
 import net.pitan76.itemalchemy.EMCManager;
-import net.pitan76.itemalchemy.gui.screen.EMCCondenserScreenHandler;
 import net.pitan76.mcpitanlib.api.gui.slot.CompatibleSlot;
 import net.pitan76.mcpitanlib.api.util.ItemStackUtil;
 import net.pitan76.mcpitanlib.api.util.inventory.ICompatInventory;
@@ -17,15 +16,19 @@ public class TargetSlot extends CompatibleSlot {
         this.screenHandler = screenHandler;
     }
 
+    /**
+     * A target slot only ever displays a copy of the item it is filtering on, so vanilla must
+     * never move anything into it. {@code safeInsert}, {@code insertItem} and the quick craft
+     * (drag) handler all hand over as much of a stack as the slot claims to accept, and
+     * {@link #callSetStack} truncating that down to one silently destroys the remainder.
+     * <p>
+     * The screen handlers set the displayed item themselves instead, so refusing every
+     * insertion here costs nothing and closes every path at once — including the ones that
+     * bypass {@code onSlotClick}, such as the single slot shortcut in the drag handler.
+     */
     @Override
     public boolean canInsert(ItemStack stack) {
-        if (screenHandler instanceof EMCCondenserScreenHandler) {
-            EMCCondenserScreenHandler handler = (EMCCondenserScreenHandler) screenHandler;
-
-            return EMCManager.get(stack) != 0 && !stack.isEmpty() && handler.targetStack.isEmpty();
-        }
-
-        return EMCManager.get(stack) != 0 && !stack.isEmpty();
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Fixes #165.

## Problem

The EMC Collector's target slot — the rightmost one, used to stop an item from evolving
any further — destroys items. Dragging a stack onto it leaves a single item behind and the
rest is gone, and shift clicking the slot afterwards removes what is left without giving
anything back.

Reproduced on MC 26.1.2 (Fabric), Item Alchemy 1.3.3.

## Cause

The slot only ever holds one item, and `TargetSlot.callSetStack` enforces that by truncating
whatever it is handed. Vanilla was never told about the limit, so `safeInsert`, `insertItem`
and the quick craft (drag) handler all move as much of a stack in as they like, and the
truncation silently destroys the remainder.

`EMCCollectorScreenHandler.onSlotClick` papered over this by putting the cursor back after
letting vanilla do the move:

```java
ItemStack oldStack = getCursorStackM().copy();
super.onSlotClick(e);                                  // destroys 63 of 64
if (!oldStack.isEmpty()) setCursorStack(oldStack);     // recreates 64
```

Those two bugs cancel out, but only when that restore actually runs. It does not when
vanilla reaches the slot through `AbstractContainerMenu#doClick`, which the quick craft
handler uses for its single slot shortcut and which never goes through `onSlotClick`.

I traced it with a temporary log around the click handler. Dragging a stack of 64 coal onto
the slot, before the fix:

```
>>> SERVER slot=-999 button=0 action=QUICK_CRAFT carried=64xcoal                    drag start
>>> SERVER slot=37   button=1 action=QUICK_CRAFT carried=64xcoal slotItem=1xcoal    drag over target slot
>>> SERVER slot=-999 button=2 action=QUICK_CRAFT carried=64xcoal                    drag end
<<< SERVER slot=-999                             carried=1xcoal                     63 destroyed
```

Client and server agreed, so this is not a desync — the items really were destroyed.

## Fix

Refuse every insertion in `TargetSlot.canInsert` and set the displayed item directly in
`onSlotClick`, the way `EMCCondenserScreenHandler` already does. Vanilla then never moves
the player's items into the slot, which closes the paths that bypass `onSlotClick` as well.

`insertItem` needs one extra step. Only its empty slot pass consults `canInsert`; the pass
that merges into an already occupied slot does not, and writes the count straight onto the
stack in the slot:

```
  merge into occupied:  isStackable -> isSameItemSameComponents -> getMaxStackSize -> setCount
  fill empty slot:      mayPlace -> getMaxStackSize -> split -> setByPlayer
```

`quickMoveOverride` therefore skips slot 37 explicitly rather than relying on `canInsert`.

## Verification

Built and tested on MC 26.1.2, Fabric, single player, with the same trace still in place.
After the fix, holding 64 coal:

```
slot=27 PICKUP      carried=EMPTY   -> carried=64xcoal                     pick the stack up
slot=37 QUICK_MOVE  carried=64xcoal -> carried=64xcoal  slotItem=1xcoal    filter set, nothing lost
slot=37 QUICK_MOVE  x8, left and right button           carried stays 64
slot=37 PICKUP      carried=64xcoal -> carried=64xcoal                     nothing lost
slot=16 PICKUP      carried=64xcoal -> slotItem=64xcoal                    all 64 back in the inventory
slot=37 QUICK_MOVE  carried=EMPTY   -> slotItem=EMPTY                      filter cleared, nothing lost
```

The carried count never drops. Setting and clearing the filter both still work.

The EMC Condenser shares `TargetSlot`, so it was checked too — setting a target, dragging a
stack onto the slot and shift clicking it all behave correctly and lose nothing. Its own
`onSlotClick` already set the displayed item directly, so it only gains the protection
against the paths that bypass it.
